### PR TITLE
Use busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY settings.xml /settings.xml
 RUN mvn -f /build/pom.xml --batch-mode -Pproduction -Pnative native:compile -Dmaven.test.skip=true -gs /settings.xml
 
 # create runtime container
-FROM ubuntu:24.04
-COPY --from=build /build/target/product-listing-service /
+FROM busybox
+COPY --from=build /build/target/product-listing-service .
 CMD ["/product-listing-service"]
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,9 @@
                 <artifactId>native-maven-plugin</artifactId>
                 <configuration>
                   <buildArgs>
-                <!-- needed because our servers has only old cpu features -->
+                      <!-- needed because our servers has only old cpu features -->
                       <buildArg>-march=x86-64-v2</buildArg>
+                      <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg>
                   </buildArgs>
                 </configuration>
               </plugin>
@@ -119,10 +120,10 @@
         </profile>
     
         <profile>
-      <!-- Production mode is activated using -Pproduction -->
+            <!-- Production mode is activated using -Pproduction -->
             <id>production</id>
             <dependencies>
-        <!-- Exclude development dependencies from production -->
+                <!-- Exclude development dependencies from production -->
                 <dependency>
                     <groupId>com.vaadin</groupId>
                     <artifactId>vaadin-core</artifactId>


### PR DESCRIPTION
Can't build a complete static binary:
https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/

Therefore it seems I can't use scratch container. Busybox is also very small 1mb-5mb but seems to have some very low level c-libraries with in.
