### PR TITLE
Change base docker image to 24.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM container-registry.oracle.com/graalvm/native-image:24 AS build
+FROM container-registry.oracle.com/graalvm/native-image:24.0.1 AS build
 
 # install maven
 ARG MAVEN_VERSION=3.9.9


### PR DESCRIPTION
24 points since about 20 hours to 24.0.2 and maybe other things changed also.
At least the current v24 can not be run on our infra because of a error: "product-listing-service  | /product-listing-service: CPU ISA level is lower than required"

Downgrading to 24.0.1 which seems to be about 3 months old seems to work.
However I do not have much experience with graal and native images so may you can have a look at it when you are back @alexsuter 